### PR TITLE
Fix/screenshot image android error

### DIFF
--- a/android/src/main/java/jpg/ivan/native_screenshot/NativeScreenshotPlugin.java
+++ b/android/src/main/java/jpg/ivan/native_screenshot/NativeScreenshotPlugin.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;

--- a/android/src/main/java/jpg/ivan/native_screenshot/NativeScreenshotPlugin.java
+++ b/android/src/main/java/jpg/ivan/native_screenshot/NativeScreenshotPlugin.java
@@ -140,10 +140,13 @@ public class NativeScreenshotPlugin implements MethodCallHandler, FlutterPlugin,
 		}
 		if (call.method.equals("takeScreenshotImage")) {
 			int quality = 100;
-			ArrayList arguments = (ArrayList) call.arguments;
+
+			HashMap arguments = call.arguments;
+			System.out.println(arguments);
 			if(arguments.size() > 0) {
-				quality = (Integer) arguments.get(0);
+				quality = (Integer) arguments.get("quality");
 			}
+
 			handleTakeScreenshotImage(result, quality);
 			return;
 		}

--- a/android/src/main/java/jpg/ivan/native_screenshot/NativeScreenshotPlugin.java
+++ b/android/src/main/java/jpg/ivan/native_screenshot/NativeScreenshotPlugin.java
@@ -143,7 +143,7 @@ public class NativeScreenshotPlugin implements MethodCallHandler, FlutterPlugin,
 			int quality = 100;
 
 			HashMap arguments = (HashMap) call.arguments;
-			System.out.println(arguments);
+			
 			if(arguments.size() > 0) {
 				quality = (Integer) arguments.get("quality");
 			}

--- a/android/src/main/java/jpg/ivan/native_screenshot/NativeScreenshotPlugin.java
+++ b/android/src/main/java/jpg/ivan/native_screenshot/NativeScreenshotPlugin.java
@@ -142,7 +142,7 @@ public class NativeScreenshotPlugin implements MethodCallHandler, FlutterPlugin,
 		if (call.method.equals("takeScreenshotImage")) {
 			int quality = 100;
 
-			HashMap arguments = call.arguments;
+			HashMap arguments = (HashMap) call.arguments;
 			System.out.println(arguments);
 			if(arguments.size() > 0) {
 				quality = (Integer) arguments.get("quality");


### PR DESCRIPTION
When trying to call the takeScreenshotImage method, it throws an error saying that call.arguments cannot be converted from HashMap to ArrayList. This PR aims to solve this error by getting the quality arguments from the HashMap.